### PR TITLE
Decouple sampledir workdir

### DIFF
--- a/Generate_assignment_report.pl
+++ b/Generate_assignment_report.pl
@@ -17,17 +17,16 @@ my $usage = '
 This script will read corresponding files in the given director and 
 generate a report. 
 
-perl script <sample dir> 
+perl script <sample dir> <sample name>
 <sample dir> = full path to the directory holding files for the given 
                library without the last "/"
                e.g. ~/tools/Illumina_VirusDiscoveryPipeline/data/MiSeq_run_1/I10_12310_Project404_CSF_Glaser_Encephalitis_V11T00919_TruSeq-AD007_CAGATC
+<sample name> = sample name
 
 ';
-die $usage unless scalar @ARGV == 1;
-my ( $dir ) = @ARGV;
+die $usage unless scalar @ARGV == 2;
+my ( $dir, $sample_name ) = @ARGV;
 
-my @temp = split("\/", $dir);
-my $sample_name = pop @temp;
 # print "lib is $sample_name\n";
 
 ####################################

--- a/Generate_assignment_summary.pl
+++ b/Generate_assignment_summary.pl
@@ -23,17 +23,16 @@ It will rank the virus lineage by range of percent ID from low to high.
 It will generate a .InterestingReads report about the details of each lineage
 and the sequence of reads belong to this lineage.
 
-perl script <sample folder> 
+perl script <sample folder> <sample name>
 <sample folder> = full path to the folder holding files for a given sample 
+<sample name> = sample name
 
 ';
 
-die $usage unless scalar @ARGV == 1;
-my ( $dir ) = @ARGV;
+die $usage unless scalar @ARGV == 2;
+my ( $dir, $lib_name ) = @ARGV;
 
 
-my @temp = split("\/", $dir);
-my $lib_name = pop @temp;
 
 # generate viral reads assignment summary
 my $out = $dir."/".$lib_name.".AssignmentSummary";

--- a/Masked_seq_to_unmasked_seq.pl
+++ b/Masked_seq_to_unmasked_seq.pl
@@ -16,18 +16,16 @@ This script will read sequence in RepeatMasker.goodSeq.RefGenome.unmapped.unmask
 corresponding masked sequence in the file .QCed.cdhit.fa 
 and output to a file RepeatMasker.goodSeq.RefGenome.unmapped.masked.fasta
 
-perl script <sample dir>
+perl script <sample dir> <sample name>
 <sample dir> = full path of the folder holding files for this sample
                without last "/"
+<sample name> = sample name
 
 ';
-die $usage unless scalar @ARGV == 1;
-my ( $dir ) = @ARGV;
+die $usage unless scalar @ARGV == 2;
+my ( $dir, $SampleName ) = @ARGV;
 my $percent_masked_cutoff = 0.4;
 
-# get directory path
-my @fields = split(/\//, $dir);
-my $SampleName = $fields[$#fields];
 
 
 my $UnmaskedFile = $dir."/".$SampleName.".QCed.cdhit.fa";

--- a/Phage_Generate_assignment_report.pl
+++ b/Phage_Generate_assignment_report.pl
@@ -16,18 +16,16 @@ my $usage = '
 This script will read corresponding files in the given director and 
 generate a report for all the phage sequences. 
 
-perl script <sample dir> 
+perl script <sample dir> <sample name>
 <sample dir> = full path to the directory holding files for the given 
                library without the last "/"
                e.g. ~/tools/Illumina_VirusDiscoveryPipeline/data/MiSeq_run_1/I10_12310_Project404_CSF_Glaser_Encephalitis_V11T00919_TruSeq-AD007_CAGATC
+<sample name> = sample name
 
 ';
-die $usage unless scalar @ARGV == 1;
-my ( $dir ) = @ARGV;
+die $usage unless scalar @ARGV == 2;
+my ( $dir, $sample_name ) = @ARGV;
 
-my @temp = split("\/", $dir);
-my $sample_name = pop @temp;
-# print "lib is $sample_name\n";
 
 ####################################
 # read in original sequences

--- a/Phage_Generate_assignment_summary.pl
+++ b/Phage_Generate_assignment_summary.pl
@@ -15,16 +15,15 @@ This script will read the phage assignment report files in the given
 directory and generate a phage summary report for a given library. 
 It will rank the phage lineage by range of percent ID from low to high. 
 
-perl script <sample folder> 
+perl script <sample folder> <sample name>
 <sample folder> = full path to the folder holding files for a given sample 
+<sample name> = sample name
 
 ';
 
-die $usage unless scalar @ARGV == 1;
-my ( $dir ) = @ARGV;
+die $usage unless scalar @ARGV == 2;
+my ( $dir, $lib_name ) = @ARGV;
 
-my @temp = split("\/", $dir);
-my $lib_name = pop @temp;
 
 # generate viral reads assignment summary
 my $out = $dir."/".$lib_name.".PhageAssignmentSummary";

--- a/RepeatMasker_SequenceQualityControl.pl
+++ b/RepeatMasker_SequenceQualityControl.pl
@@ -22,18 +22,16 @@ into file .RepeatMasker.RepeatLowComplexSeq.fa
 3) good sequences are put into .RepeatMasker.goodSeq.masked.fa (for BLAST)
 and .RepeatMasker.goodSeq.unmasked.fa (for mapping)
 
-perl script <sample dir>
+perl script <sample dir> <sample name>
 <sample dir> = full path of the folder holding files for this sample
                without last "/"
+<sample name> = sample name
 
 ';
-die $usage unless scalar @ARGV == 1;
-my ( $dir ) = @ARGV;
+die $usage unless scalar @ARGV == 2;
+my ( $dir, $SampleName ) = @ARGV;
 my $percent_masked_cutoff = 0.4;
 
-# get directory path
-my @fields = split(/\//, $dir);
-my $SampleName = $fields[$#fields];
 
 my $total_seq = 0;
 my $good_seq = 0;

--- a/RepeatMasker_check_SequenceQualityControl.pl
+++ b/RepeatMasker_check_SequenceQualityControl.pl
@@ -1,18 +1,17 @@
 #!/usr/bin/perl -w
 use strict;
 my $usage='
-perl script <sample dir>
+perl script <sample dir> <sample name>
 <sample dir> = full path of the folder holding files for a sample
+<sample name> = sample name
 
 ';
-die $usage unless scalar @ARGV == 1;
-my ( $dir ) = @ARGV;
+die $usage unless scalar @ARGV == 2;
+my ( $dir, $sample_name ) = @ARGV;
 
 if ($dir =~/(.+)\/$/) {
 	$dir = $1;
 }
-my $sample_name = (split(/\//,$dir))[-1];
-#print $sample_name,"\n";
 
 my $finished = &check_QC_read_number($dir);
 #print $finished; 

--- a/Tantan_Sequence_Quality_Control.pl
+++ b/Tantan_Sequence_Quality_Control.pl
@@ -23,20 +23,19 @@ sequence without N will be put into file .cdhit_out.masked.badSeq
 into file .cdhit_out.masked.RepeatLowComplexSeq
 3) output original sequnce into .cdhit_out.masked.goodSeq file.
 
-perl script <dir>
+perl script <dir> <sample name>
 <dir> = full path to the file without the last "/"
+<sample name> = sample name
 
 ';
-die $usage unless scalar @ARGV == 1;
-my ( $dir ) = @ARGV;
+die $usage unless scalar @ARGV == 2;
+my ( $dir, $sample_name ) = @ARGV;
 
 ####################################################################################################
 # get name of the sample and path to the data
 if ($dir =~/(.+)\/$/) {
 	$dir = $1;
 }
-my $sample_name = (split(/\//,$dir))[-1];
-print $sample_name,"\n";
 
 my $original_fa_file = $dir."/".$sample_name.".QCed.cdhit.tantan.fa";
 my %original_fa_seq = ();

--- a/Unmasked_seq_to_masked_seq.pl
+++ b/Unmasked_seq_to_masked_seq.pl
@@ -16,18 +16,16 @@ This script will read sequence in RepeatMasker.goodSeq.RefGenome.unmapped.unmask
 corresponding masked sequence in the file .QCed.cdhit.fa 
 and output to a file RepeatMasker.goodSeq.RefGenome.unmapped.masked.fasta
 
-perl script <sample dir>
+perl script <sample dir> <sample name>
 <sample dir> = full path of the folder holding files for this sample
                without last "/"
+<sample name> = sample name
 
 ';
-die $usage unless scalar @ARGV == 1;
-my ( $dir ) = @ARGV;
+die $usage unless scalar @ARGV == 2;
+my ( $dir, $SampleName ) = @ARGV;
 my $percent_masked_cutoff = 0.4;
 
-# get directory path
-my @fields = split(/\//, $dir);
-my $SampleName = $fields[$#fields];
 
 my $maskedFile = $dir."/".$SampleName.".RepeatMasker.goodSeq.masked.fa";
 my %maskedSeq = ();

--- a/Unmasked_seq_to_masked_seq_After_BacteriaMapping.pl
+++ b/Unmasked_seq_to_masked_seq_After_BacteriaMapping.pl
@@ -16,18 +16,16 @@ This script will read sequence in RepeatMasker.goodSeq.RefGenome.unmapped.unmask
 corresponding masked sequence in the file .QCed.cdhit.fa 
 and output to a file RepeatMasker.goodSeq.RefGenome.unmapped.masked.fasta
 
-perl script <sample dir>
+perl script <sample dir> <sample name>
 <sample dir> = full path of the folder holding files for this sample
                without last "/"
+<sample name> = sample name
 
 ';
-die $usage unless scalar @ARGV == 1;
-my ( $dir ) = @ARGV;
+die $usage unless scalar @ARGV == 2;
+my ( $dir, $SampleName ) = @ARGV;
 my $percent_masked_cutoff = 0.4;
 
-# get directory path
-my @fields = split(/\//, $dir);
-my $SampleName = $fields[$#fields];
 
 my $maskedFile = $dir."/".$SampleName.".RepeatMasker.goodSeq.masked.fa";
 my %maskedSeq = ();

--- a/VirusSeeker_Virome_v0.063_cdhit984.pl
+++ b/VirusSeeker_Virome_v0.063_cdhit984.pl
@@ -816,7 +816,7 @@ sub seq_QC_TANTAN {
 
 	print STCH "if [ ! -e $status_log/j7_QC_TANTAN_finished ]\n";
 	print STCH "then\n";
-	print STCH "	".$run_script_path."Tantan_Sequence_Quality_Control.pl ".$sample_dir."\n";
+	print STCH "	".$run_script_path."Tantan_Sequence_Quality_Control.pl ${sample_dir} ${sample_name}\n";
 	print STCH "	OUT=\$?\n"; 
 	print STCH '	if [ ${OUT} -ne 0 ]',"\n"; # did not finish successfully
 	print STCH "	then\n";
@@ -862,7 +862,7 @@ sub prepare_for_RM {
 	# split into smaller files
 	print STCH "	".$run_script_path."FASTA_file_split_given_numberOfFiles.pl -d $sample_dir -i  \${IN} -o $repeatmasker_dir -f $file_number_of_RepeatMasker -n $num_seq_per_file_Repeatmasker \n";
 	print STCH "	CHECK1=\$?\n"; # if finishes value is 0
-	print STCH "	".$run_script_path."check_split_RepeatMasker.pl \${SAMPLE_DIR}\n";
+	print STCH "	".$run_script_path."check_split_RepeatMasker.pl ${sample_dir} ${sample_name}\n";
 	print STCH "	CHECK2=\$?\n"; # if finishes correctly value is 0
 	print STCH "	if [ \${CHECK1} -ne 0 -o \${CHECK2} -ne 0 ] \n"; 
 	print STCH "	then\n";
@@ -954,9 +954,9 @@ sub seq_RMQC {
 
 	print STCH "if [ ! -e $status_log/j10_RMQC_output_finished ]\n";
 	print STCH "then\n";
-	print STCH "	".$run_script_path."RepeatMasker_SequenceQualityControl.pl ".$sample_dir."\n";
+	print STCH "	".$run_script_path."RepeatMasker_SequenceQualityControl.pl ${sample_dir} ${sample_name}\n";
 	print STCH '	CHECK1=$?',"\n"; # if finishes value is 0
-	print STCH "	".$run_script_path."RepeatMasker_check_SequenceQualityControl.pl \${SAMPLE_DIR} > \${QC_Record} \n";
+	print STCH "	".$run_script_path."RepeatMasker_check_SequenceQualityControl.pl ${sample_dir} ${sample_name} > \${QC_Record} \n";
 	print STCH '	CHECK2=$?',"\n"; # if finishes correctly value is 0
 	print STCH '	if [ ${CHECK1} -ne 0 -o ${CHECK2} -ne 0 ]',"\n"; # either one is not finished correctly
 	print STCH "	then\n";
@@ -1058,7 +1058,7 @@ sub Extract_Host_unmapped_reads{
 	print STCH "	OUT3=\$?\n";
 
 	# change unmasked sequence to masked sequence for BLAST
-	print STCH "	".$run_script_path."Unmasked_seq_to_masked_seq.pl $sample_dir \n"; 
+	print STCH "	".$run_script_path."Unmasked_seq_to_masked_seq.pl ${sample_dir} ${sample_name}\n"; 
 	print STCH "	OUT4=\$?\n";
 	# did not finish successfully
 	print STCH '	if [ ${OUT1} -ne 0 ] || [ ${OUT2} -ne 0 ] || [ ${OUT3} -ne 0 ] || [ ${OUT4} -ne 0 ] ',"\n"; 
@@ -1275,7 +1275,7 @@ sub extract_RefGenomeFiltered_reads{
 	print STCH "	QC_Record=".$sample_dir."/".$sample_name.".MegaBLAST_HOST_finish_check.txt\n\n";
 
 	# check to make sure all MegaBLAST finished and parser finished correctly
-	print STCH "	".$run_script_path."check_MegaBLAST_HOST_Finished_correctly.pl \${SAMPLE_DIR} > \${QC_Record}  \n";
+	print STCH "	".$run_script_path."check_MegaBLAST_HOST_Finished_correctly.pl ${sample_dir} ${sample_name} > \${QC_Record}  \n";
 	print STCH "	OUT=\$?\n"; 
 	print STCH '	if [ ${OUT} -ne 0 ]',"\n"; # did not finish successfully
 	print STCH "	then\n";
@@ -1485,7 +1485,7 @@ sub split_for_BLASTX_VIRUSDB {
 	print STCH "if [ ! -e $status_log/j20_finished_split_for_BLASTX_VIRUSDB ]\n";
 	print STCH "then\n";
 	# check to make sure the number of reads add togetehr equals the total input reads
-	print STCH "	".$run_script_path."check_BLASTN_VIRUSDB_Finished_correctly.pl \${SAMPLE_DIR} > \${QC_Record}  \n";
+	print STCH "	".$run_script_path."check_BLASTN_VIRUSDB_Finished_correctly.pl ${sample_dir} ${sample_name} > \${QC_Record}  \n";
 	print STCH "	OUT=\$?\n"; 
 	print STCH '	if [ ${OUT} -ne 0 ]',"\n"; # did not finish successfully
 	print STCH "	then\n";
@@ -1528,7 +1528,7 @@ sub split_for_BLASTX_VIRUSDB {
 	# the number of blast job array submitted bellow
 	print STCH "	".$run_script_path."FASTA_file_split_given_numberOfFiles.pl -d \${SAMPLE_DIR} -i  \${BLASTN_VIRUSDB_Filtered_fa} -o \${BLASTX_VIRUSDB_DIR} -f $file_number_of_BLASTX_VIRUSDB  -n $num_seq_per_file_BLASTX_VIRUSDB \n";
 	print STCH '	CHECK1=$?',"\n";
-	print STCH "	".$run_script_path."check_split_BLASTX_VIRUSDB.pl \${SAMPLE_DIR}\n";
+	print STCH "	".$run_script_path."check_split_BLASTX_VIRUSDB.pl ${sample_dir} ${sample_name}\n";
 	print STCH '	CHECK2=$?',"\n";
 #	print STCH '	echo ${CHECK1}, ${CHECK2}', "\n";
 	print STCH '	if [ ${CHECK1} -ne 0 -o ${CHECK2} -ne 0 ]',"\n"; 
@@ -1693,7 +1693,7 @@ sub pool_seq_for_mapping_Bacteria {
 	print STCH "then\n";
 
 	# check to make sure the number of reads add togetehr equals the total input reads
-	print STCH "	".$run_script_path."check_BLASTX_VIRUSDB_Finished_correctly.pl \${SAMPLE_DIR} > \${QC_Record}  \n";
+	print STCH "	".$run_script_path."check_BLASTX_VIRUSDB_Finished_correctly.pl ${sample_dir} ${sample_name} > \${QC_Record}  \n";
 	print STCH "	OUT=\$?\n"; 
 	print STCH '	if [ ${OUT} -ne 0 ]',"\n"; # did not finish successfully
 	print STCH "	then\n";
@@ -1730,7 +1730,7 @@ sub pool_seq_for_mapping_Bacteria {
 	print STCH "	cat  $sample_dir/\${BLASTX_VIRUSDB_Hit_fa} $sample_dir/\${BLASTN_VIRUSDB_Hit_fa} > \${SAMPLE_DIR}/\${VIRUSDB_HIT_all} \n";
 
 	# change masked sequence to unmasked sequence for mapping to Bacteria
-	print STCH "	".$run_script_path."Masked_seq_to_unmasked_seq.pl $sample_dir \n"; 
+	print STCH "	".$run_script_path."Masked_seq_to_unmasked_seq.pl ${sample_dir} ${sample_name}\n"; 
 	print STCH "	OUT=\$?\n"; 
 	print STCH '	if [ ${OUT} -ne 0 ]',"\n"; # did not finish successfully
 	print STCH "	then\n";
@@ -1835,7 +1835,7 @@ sub Extract_Bacteria_unmapped_reads{
 	print STCH "	fi\n";
     
 	# change unmasked sequence to masked for BLAST
-	print STCH "	".$run_script_path."Unmasked_seq_to_masked_seq_After_BacteriaMapping.pl $sample_dir \n"; 
+	print STCH "	".$run_script_path."Unmasked_seq_to_masked_seq_After_BacteriaMapping.pl ${sample_dir} ${sample_name}\n"; 
  	print STCH "	OUT=\$?\n"; 
 	print STCH '	if [ ${OUT} -ne 0 ]',"\n"; # did not finish successfully
 	print STCH "	then\n";
@@ -1881,7 +1881,7 @@ sub split_for_MegaBLAST_NT{
 
 	# split into smaller files
 	print STCH "	".$run_script_path."FASTA_file_split_given_numberOfFiles.pl -d $sample_dir -i \${IN} -o \${MegaBLAST_DIR}   -f $file_number_of_MegaBLAST_NT -n $num_seq_per_file_MegaBLAST_NT \n";
-	print STCH "	".$run_script_path."check_split_MegaBLAST_NT.pl $sample_dir \n";
+	print STCH "	".$run_script_path."check_split_MegaBLAST_NT.pl ${sample_dir} ${sample_name}\n";
  	print STCH "	OUT=\$?\n"; 
 	print STCH '	if [ ${OUT} -ne 0 ]',"\n"; # did not finish successfully
 	print STCH "	then\n";
@@ -2040,7 +2040,7 @@ sub pool_split_for_BlastN{
 	print STCH "if [ ! -e $status_log/j29_finished_split_for_BLASTN_NT ]\n"; # job never finished
 	print STCH "then\n";
 	# check to make sure all parser finished 
-	print STCH "	".$run_script_path."check_MegaBLAST_NT_Finished_correctly.pl \${SAMPLE_DIR} > \${QC_Record}  \n";
+	print STCH "	".$run_script_path."check_MegaBLAST_NT_Finished_correctly.pl ${sample_dir} ${sample_name} > \${QC_Record}  \n";
 	print STCH "	OUT=\$?\n"; 
 	print STCH '	if [ ${OUT} -ne 0 ]',"\n"; # did not finish successfully
 	print STCH "	then\n";
@@ -2066,7 +2066,7 @@ sub pool_split_for_BlastN{
 	
 	# split into smaller files
 	print STCH "	".$run_script_path."FASTA_file_split_given_numberOfFiles.pl -d $sample_dir -i \${MegaBLAST_Filtered_fa} -o \${BLASTN_NT_DIR}   -f $file_number_of_BLASTN -n $num_seq_per_file_BLASTN \n";
-	print STCH "	".$run_script_path."check_split_BN.pl $sample_dir \n";
+	print STCH "	".$run_script_path."check_split_BN.pl ${sample_dir} ${sample_name}\n";
  	print STCH "	OUT=\$?\n"; 
 	print STCH '	if [ ${OUT} -ne 0 ]',"\n"; # did not finish successfully
 	print STCH "	then\n";
@@ -2225,7 +2225,7 @@ sub pool_split_for_BLASTX{
 	print STCH "if [ ! -e $status_log/j32_BX_split_finished ]\n"; # job never finished
 	print STCH "then\n";
 	# check to make sure all parser finished 
-	print STCH "	".$run_script_path."check_BLAST_NT_Finished_correctly.pl \${SAMPLE_DIR} > \${QC_Record}  \n";
+	print STCH "	".$run_script_path."check_BLAST_NT_Finished_correctly.pl ${sample_dir} ${sample_name} > \${QC_Record}  \n";
 	print STCH "	OUT=\$?\n"; 
 	print STCH '	if [ ${OUT} -ne 0 ]',"\n"; # did not finish successfully
 	print STCH "	then\n";
@@ -2246,7 +2246,7 @@ sub pool_split_for_BLASTX{
 	print STCH "	cat $BLASTN_NT_dir/*.BNfiltered.fa >> $sample_dir/\${BNFiltered_fa}\n";
 
 	print STCH "	".$run_script_path."FASTA_file_split_given_numberOfFiles.pl -d $sample_dir -i \${BNFiltered_fa}  -o \${BX_DIR} -f $file_number_of_BLASTX -n $num_seq_per_file_BLASTX \n";
-	print STCH "	".$run_script_path."check_split_BX.pl ".$sample_dir."\n";
+	print STCH "	".$run_script_path."check_split_BX.pl ${sample_dir} ${sample_name} \n";
  	print STCH "	OUT=\$?\n"; 
 	print STCH '	if [ ${OUT} -ne 0 ]',"\n"; # did not finish successfully
 	print STCH "	then\n";
@@ -2410,7 +2410,7 @@ sub generate_assignment_report{
 
 	# check to make sure all parser finished 
 
-	print STCH "	".$run_script_path."check_BLASTX_NR_Finished_correctly.pl \${SAMPLE_DIR} > \${QC_Record}  \n";
+	print STCH "	".$run_script_path."check_BLASTX_NR_Finished_correctly.pl ${sample_dir} ${sample_name} > \${QC_Record}  \n";
 	print STCH "	OUT=\$?\n"; 
 	print STCH '	if [ ${OUT} -ne 0 ]',"\n"; # did not finish successfully
 	print STCH "	then\n";
@@ -2418,7 +2418,7 @@ sub generate_assignment_report{
 	print STCH "		exit 1\n"; 
 	print STCH "	fi\n";
 
-	print STCH "	".$run_script_path."Generate_assignment_report.pl ".$sample_dir." \${INPUT}\n";
+	print STCH "	".$run_script_path."Generate_assignment_report.pl ${sample_dir} ${sample_name}\n";
 	print STCH '	grep "# Finished Assignment Report" ${REPORT}',"\n";
 	print STCH '	CHECK=$?',"\n";
 	print STCH '	if [ ${CHECK} -ne 0 ]',"\n";   
@@ -2451,7 +2451,7 @@ sub generate_assignment_summary {
 	print STCH "if [ ! -e $status_log/j36_AssignmentSummary_finished ]\n"; # job never finished
 	print STCH "then\n";
 	print STCH "	date > \${TIMEFILE}\n";
-	print STCH "	".$run_script_path."Generate_assignment_summary.pl ".$sample_dir." \${BAD_SEQ}\n";
+	print STCH "	".$run_script_path."Generate_assignment_summary.pl ${sample_dir} ${sample_name}\n";
  	print STCH "	OUT=\$?\n"; 
 	print STCH '	if [ ${OUT} -ne 0 ]',"\n"; # did not finish successfully
 	print STCH "	then\n";
@@ -2486,7 +2486,7 @@ sub generate_phage_report{
 	print STCH "if [ ! -e $status_log/j37_PhageAssignmentReport_finished ]\n"; # job never finished
 	print STCH "then\n";
 	print STCH "	date > \${TIMEFILE}\n";
-	print STCH "	".$run_script_path."Phage_Generate_assignment_report.pl ".$sample_dir."\n";
+	print STCH "	".$run_script_path."Phage_Generate_assignment_report.pl ${sample_dir} ${sample_name}\n";
 	print STCH '	grep "# Finished Assignment Report" ${REPORT}',"\n";
 	print STCH '	CHECK=$?',"\n";
 	print STCH '	if [ ${CHECK} -ne 0 ]',"\n";   
@@ -2521,7 +2521,7 @@ sub generate_phage_summary {
 	print STCH '	CHECK=1',"\n";
 	print STCH '	while [ ${CHECK} -ne 0 ] ',"\n"; 
 	print STCH "	do\n";
-	print STCH "		".$run_script_path."Phage_Generate_assignment_summary.pl ".$sample_dir."\n";
+	print STCH "		".$run_script_path."Phage_Generate_assignment_summary.pl ${sample_dir} ${sample_name}\n";
 	print STCH '		grep "# Finished Assignment Summary" ${OUTPUT}',"\n";
 	print STCH '		CHECK=$?',"\n";
 	print STCH "	done\n";

--- a/VirusSeeker_Virome_v0.063_cdhit984.pl
+++ b/VirusSeeker_Virome_v0.063_cdhit984.pl
@@ -35,7 +35,7 @@ my $normal = "\e[0m";
 This script will run the Metagenomic pipeline use Slurm Workload Manager.
 
 Pipeline version: $version
-$yellow		Usage: perl $0 <sample_folder><ref genome><use checkpointing> <step_number> $normal
+$yellow		Usage: perl $0 <sample_folder><ref genome><use checkpointing> <step_number> [workdir] $normal
 
 <sample_folder> = full path of the folder holding files for the sample
 <ref genome> = 1. Human genome
@@ -44,6 +44,8 @@ $yellow		Usage: perl $0 <sample_folder><ref genome><use checkpointing> <step_num
                4. Worm (C. brenneri)
                5. Mouse lemur (Microcebus_murinus)
 <use checkpointing> = 1. yes, 0. no
+
+[workdir] = working directory (default: ./workdir/)
 
 <step_number> = [1..38] run this pipeline step by step. (running the whole pipeline if step number is 0)
 $red	[1] Remove Adapter
@@ -97,11 +99,13 @@ $red	[37]  Generate phage report
 $normal
 OUT
 
-die $usage unless scalar @ARGV == 4;
-my ($sample_dir, $ref_genome_choice, $use_checkpoint,  $step_number) = @ARGV;
+die $usage unless scalar @ARGV >= 4;
+my ($sample_dir, $ref_genome_choice, $use_checkpoint,  $step_number, $workdir) = @ARGV;
 die $usage unless (($step_number >= 0)&&($step_number <= 38)) ;
 
-my $workdir = "outdir";
+if ($workdir eq "") {
+    $workdir = "workdir";
+}
 
 #####################################################################################
 # get name of the sample and path to the data

--- a/VirusSeeker_Virome_v0.063_cdhit984.pl
+++ b/VirusSeeker_Virome_v0.063_cdhit984.pl
@@ -103,7 +103,7 @@ die $usage unless scalar @ARGV >= 4;
 my ($sample_dir, $ref_genome_choice, $use_checkpoint,  $step_number, $workdir) = @ARGV;
 die $usage unless (($step_number >= 0)&&($step_number <= 38)) ;
 
-if ($workdir eq "") {
+if (! $workdir or $workdir eq "") {
     $workdir = "workdir";
 }
 

--- a/check_BLASTN_VIRUSDB_Finished_correctly.pl
+++ b/check_BLASTN_VIRUSDB_Finished_correctly.pl
@@ -1,18 +1,18 @@
 #!/usr/bin/perl -w
 use strict;
 my $usage='
-perl script <sample dir>
+perl script <sample dir> <sample name>
 <sample dir> = full path of the folder holding files for this sample
                without last "/"
+<sample name> = sample name
+
 ';
-die $usage unless scalar @ARGV == 1;
-my ( $dir ) = @ARGV;
+die $usage unless scalar @ARGV == 2;
+my ( $dir, $sample_name ) = @ARGV;
 
 if ($dir =~/(.+)\/$/) {
         $dir = $1;
 }
-my $sample_name = (split(/\//,$dir))[-1];
-#print $sample_name,"\n";
 
 my $finished = &check_split_output($dir);
 #print $finished; 

--- a/check_BLASTX_NR_Finished_correctly.pl
+++ b/check_BLASTX_NR_Finished_correctly.pl
@@ -1,18 +1,18 @@
 #!/usr/bin/perl -w
 use strict;
 my $usage='
-perl script <sample dir>
+perl script <sample dir> <sample name>
 <sample dir> = full path of the folder holding files for this sample
                without last "/"
+<sample name> = sample name
+
 ';
-die $usage unless scalar @ARGV == 1;
-my ( $dir ) = @ARGV;
+die $usage unless scalar @ARGV == 2;
+my ( $dir, $sample_name ) = @ARGV;
 
 if ($dir =~/(.+)\/$/) {
         $dir = $1;
 }
-my $sample_name = (split(/\//,$dir))[-1];
-#print $sample_name,"\n";
 
 my $finished = &check_split_output($dir);
 #print $finished; 

--- a/check_BLASTX_VIRUSDB_Finished_correctly.pl
+++ b/check_BLASTX_VIRUSDB_Finished_correctly.pl
@@ -1,18 +1,18 @@
 #!/usr/bin/perl -w
 use strict;
 my $usage='
-perl script <sample dir>
+perl script <sample dir> <sample name>
 <sample dir> = full path of the folder holding files for this sample
                without last "/"
+<sample name> = sample name
+
 ';
-die $usage unless scalar @ARGV == 1;
-my ( $dir ) = @ARGV;
+die $usage unless scalar @ARGV == 2;
+my ( $dir, $sample_name ) = @ARGV;
 
 if ($dir =~/(.+)\/$/) {
         $dir = $1;
 }
-my $sample_name = (split(/\//,$dir))[-1];
-#print $sample_name,"\n";
 
 my $finished = &check_split_output($dir);
 #print $finished; 

--- a/check_BLAST_NT_Finished_correctly.pl
+++ b/check_BLAST_NT_Finished_correctly.pl
@@ -1,18 +1,18 @@
 #!/usr/bin/perl -w
 use strict;
 my $usage='
-perl script <sample dir>
+perl script <sample dir> <sample name>
 <sample dir> = full path of the folder holding files for this sample
                without last "/"
+<sample name> = sample name
+
 ';
-die $usage unless scalar @ARGV == 1;
-my ( $dir ) = @ARGV;
+die $usage unless scalar @ARGV == 2;
+my ( $dir, $sample_name ) = @ARGV;
 
 if ($dir =~/(.+)\/$/) {
         $dir = $1;
 }
-my $sample_name = (split(/\//,$dir))[-1];
-#print $sample_name,"\n";
 
 my $finished = &check_split_output($dir);
 #print $finished; 

--- a/check_MegaBLAST_HOST_Finished_correctly.pl
+++ b/check_MegaBLAST_HOST_Finished_correctly.pl
@@ -1,18 +1,18 @@
 #!/usr/bin/perl -w
 use strict;
 my $usage='
-perl script <sample dir>
+perl script <sample dir> <sample name>
 <sample dir> = full path of the folder holding files for this sample
                without last "/"
+<sample name> = sample name
+
 ';
-die $usage unless scalar @ARGV == 1;
-my ( $dir ) = @ARGV;
+die $usage unless scalar @ARGV == 2;
+my ( $dir, $sample_name ) = @ARGV;
 
 if ($dir =~/(.+)\/$/) {
         $dir = $1;
 }
-my $sample_name = (split(/\//,$dir))[-1];
-#print $sample_name,"\n";
 
 my $finished = &check_split_output($dir);
 #print $finished; 

--- a/check_MegaBLAST_NT_Finished_correctly.pl
+++ b/check_MegaBLAST_NT_Finished_correctly.pl
@@ -1,18 +1,18 @@
 #!/usr/bin/perl -w
 use strict;
 my $usage='
-perl script <sample dir>
+perl script <sample dir> <sample name>
 <sample dir> = full path of the folder holding files for this sample
                without last "/"
+<sample name> = sample name
+
 ';
-die $usage unless scalar @ARGV == 1;
-my ( $dir ) = @ARGV;
+die $usage unless scalar @ARGV == 2;
+my ( $dir, $sample_name ) = @ARGV;
 
 if ($dir =~/(.+)\/$/) {
         $dir = $1;
 }
-my $sample_name = (split(/\//,$dir))[-1];
-#print $sample_name,"\n";
 
 my $finished = &check_split_output($dir);
 #print $finished; 

--- a/check_split_BLASTX_VIRUSDB.pl
+++ b/check_split_BLASTX_VIRUSDB.pl
@@ -1,18 +1,17 @@
 #!/usr/bin/perl -w
 use strict;
 my $usage='
-perl script <sample dir>
+perl script <sample dir> <sample name>
 <sample dir> = full path of the folder holding files for a sample
+<sample name> = sample name
 
 ';
-die $usage unless scalar @ARGV == 1;
-my ( $dir ) = @ARGV;
+die $usage unless scalar @ARGV == 2;
+my ( $dir, $sample_name ) = @ARGV;
 
 if ($dir =~/(.+)\/$/) {
 	$dir = $1;
 }
-my $sample_name = (split(/\//,$dir))[-1];
-#print $sample_name,"\n";
 
 my $finished = &check_split($dir);
 #print $finished; 

--- a/check_split_BN.pl
+++ b/check_split_BN.pl
@@ -1,18 +1,18 @@
 #!/usr/bin/perl -w
 use strict;
 my $usage='
-perl script <sample dir>
+perl script <sample dir> <sample name>
 <sample dir> = full path of the folder holding files for this sample
                without last "/"
+<sample name> = sample name
+
 ';
-die $usage unless scalar @ARGV == 1;
-my ( $dir ) = @ARGV;
+die $usage unless scalar @ARGV == 2;
+my ( $dir, $sample_name ) = @ARGV;
 
 if ($dir =~/(.+)\/$/) {
         $dir = $1;
 }
-my $sample_name = (split(/\//,$dir))[-1];
-#print $sample_name,"\n";
 
 my $finished = &check_split_output($dir);
 #print $finished; 

--- a/check_split_BX.pl
+++ b/check_split_BX.pl
@@ -1,18 +1,18 @@
 #!/usr/bin/perl -w
 use strict;
 my $usage='
-perl script <run folder>
+perl script <sample dir> <sample name>
 <sample dir> = full path of the folder holding files for this sample
                without last "/"
+<sample name> = sample name
+
 ';
-die $usage unless scalar @ARGV == 1;
-my ( $dir ) = @ARGV;
+die $usage unless scalar @ARGV == 2;
+my ( $dir, $sample_name ) = @ARGV;
 
 if ($dir =~/(.+)\/$/) {
         $dir = $1;
 }
-my $sample_name = (split(/\//,$dir))[-1];
-#print $sample_name,"\n";
 
 my $finished = &check_split_output($dir);
 #print $finished; 

--- a/check_split_MegaBLAST_NT.pl
+++ b/check_split_MegaBLAST_NT.pl
@@ -1,18 +1,18 @@
 #!/usr/bin/perl -w
 use strict;
 my $usage='
-perl script <sample dir>
+perl script <sample dir> <sample name>
 <sample dir> = full path of the folder holding files for this sample
                without last "/"
+<sample name> = sample name
+
 ';
-die $usage unless scalar @ARGV == 1;
-my ( $dir ) = @ARGV;
+die $usage unless scalar @ARGV == 2;
+my ( $dir, $sample_name ) = @ARGV;
 
 if ($dir =~/(.+)\/$/) {
         $dir = $1;
 }
-my $sample_name = (split(/\//,$dir))[-1];
-#print $sample_name,"\n";
 
 my $finished = &check_split_output($dir);
 #print $finished; 

--- a/check_split_RepeatMasker.pl
+++ b/check_split_RepeatMasker.pl
@@ -1,19 +1,18 @@
 #!/usr/bin/perl -w
 use strict;
 (my $usage = <<OUT) =~ s/\t+//g;
-perl $0 <sample dir>
+perl $0 <sample dir> <sample name>
 <sample dir> = full path of the folder holding files for this sample without last "/"
+<sample name> = sample name
 
 OUT
 
-die $usage unless scalar @ARGV == 1;
-my ( $dir ) = @ARGV;
+die $usage unless scalar @ARGV == 2;
+my ( $dir, $sample_name ) = @ARGV;
 
 if ($dir =~/(.+)\/$/) {
         $dir = $1;
 }
-my $sample_name = (split(/\//,$dir))[-1];
-#print $sample_name,"\n";
 
 my $finished = &check_split_output($dir);
 #print $finished; 


### PR DESCRIPTION
This pull request separates the "sample" directory from the "work" directory.
This keeps the sample directory untouched and allows multiple pipelines to be run at the same time against the same sample directory since all of the output files are placed in a separate "work" directory.

An additional (optional) parameter to the VirusSeeker_Virome_v... command is added to allow for naming of the work directory.  If not included, the default name is "workdir":

    Usage: perl $0 <sample_folder> <ref genome> <use checkpointing> <step_number> [workdir]

